### PR TITLE
Restore usage info (FREEPBX-12690)

### DIFF
--- a/page.announcement.php
+++ b/page.announcement.php
@@ -15,7 +15,7 @@ switch($request["view"]){
 			$usage_list = framework_display_destination_usage(announcement_getdest($request['extdisplay']));
 			if(!empty($usage_list)){
 				$usagehtml = <<< HTML
-<div class="panel panel-default">
+<div class="panel panel-default fpbx-usageinfo">
 	<div class="panel-heading">
 		$usage_list[text]
 	</div>

--- a/page.announcement.php
+++ b/page.announcement.php
@@ -6,11 +6,26 @@ if (!defined('FREEPBX_IS_AUTH')) { die('No direct script access allowed'); }
 $request = $_REQUEST;
 $heading = _("Announcement");
 $request["view"] = !empty($request["view"]) ? $request["view"] : '';
+$usagehtml = '';
 //get unique queues
-switch($_GET["view"]){
+switch($request["view"]){
 	case "form":
-		if($request['extdisplay']){
+		if(isset($request['extdisplay'])){
 			$heading .= _(": Edit");
+			$usage_list = framework_display_destination_usage(announcement_getdest($request['extdisplay']));
+			if(!empty($usage_list)){
+				$usagehtml = <<< HTML
+<div class="panel panel-default">
+	<div class="panel-heading">
+		$usage_list[text]
+	</div>
+	<div class="panel-body">
+		$usage_list[tooltip]
+	</div>
+</div>
+
+HTML;
+			}
 		}else{
 			$heading .= _(": Add");
 		}
@@ -24,6 +39,7 @@ switch($_GET["view"]){
 ?>
 <div class="container-fluid">
 	<h1><?php echo $heading ?></h1>
+	<?php echo $usagehtml?>
 	<div class = "display full-border">
 		<div class="row">
 			<div class="col-sm-12">

--- a/views/form.php
+++ b/views/form.php
@@ -73,17 +73,6 @@ $repeatopts = '<option value=""'.($default == '' ? ' SELECTED' : '').'>'._("Disa
 foreach ($digits as $digit) {
 	$repeatopts .= '<option value="'.$digit.'"'.($digit == $default ? ' SELECTED' : '').'>'.$digit."</option>\n";
 }
-$usagehtml = '';
-if ($extdisplay) {
-	$usage_list = framework_display_destination_usage(announcement_getdest($extdisplay));
-	if (!empty($usage_list)) {
-		$usagehtml .= '<div class="well">';
-		$usagehtml .= '<h4>'.$usage_list['text'].'</h4>';
-		$usagehtml .= '<p>'.$usage_list['tooltip'].'</p>';
-		$usagehtml .='</div>';
-	}
-	echo $usagehtml;
-}
 ?>
 
 <form class="fpbx-submit" name="editAnnouncement" action="?display=announcement" method="post" onsubmit="return checkAnnouncement(editAnnouncement);" data-fpbx-delete="config.php?display=announcement&amp;extdisplay=<?php echo $extdisplay ?>&amp;action=delete">


### PR DESCRIPTION
Actually just moving usage info to a more attractive location outside of the container and its blue border. Screenshot:
<img width="1167" alt="screenshot 2017-04-28 10 01 13" src="https://cloud.githubusercontent.com/assets/1329102/25539960/32cbbf98-2bfe-11e7-9f13-1eeb0905700f.png">
